### PR TITLE
direct to https

### DIFF
--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -30,7 +30,7 @@ RUN pip install -r requirements.txt
 
 WORKDIR ${HOME}
 #Checkout version should be 4.4.0 when the new version is released 
-RUN git clone http://github.com/opencv/opencv.git && cd opencv \
+RUN git clone https://github.com/opencv/opencv.git && cd opencv \
     && git checkout 4.4.0    \
     && mkdir build && cd build              \
     && cmake -D CMAKE_BUILD_TYPE=RELEASE    \

--- a/models/.gitignore
+++ b/models/.gitignore
@@ -1,5 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore
-

--- a/models/yolov4/Config.json
+++ b/models/yolov4/Config.json
@@ -1,0 +1,20 @@
+{
+  "inference_engine_name": "yolov4_opencv_cpu_detection",
+  "confidence": 60,
+  "nms_threshold": 0.6,
+  "image": {
+    "width": 416,
+    "height": 416,
+    "scale": 0.00392,
+    "swapRB": true,
+    "crop": false,
+    "mean": {
+      "R": 0,
+      "G": 0,
+      "B": 0
+    }
+  },
+  "framework": "yolo",
+  "type": "detection",
+  "network": "network_name"
+}


### PR DESCRIPTION
Cloning a repository using a non-secure URL will take some time to resolve due to https redirection. This PR will direct to a secure URL instead of the non-secure one.